### PR TITLE
Add method to aggregate results without fetching them

### DIFF
--- a/LichessTournamentAggregator/ITournamentAggregator.cs
+++ b/LichessTournamentAggregator/ITournamentAggregator.cs
@@ -15,6 +15,13 @@ namespace LichessTournamentAggregator
         IAsyncEnumerable<AggregatedResult> AggregateResults(IEnumerable<string> tournamentIdsOrUrls);
 
         /// <summary>
+        /// Aggregates the results of multiple tournaments
+        /// </summary>
+        /// <param name="tournamentResults"> <see cref="TournamentResult"/> </param>
+        /// <returns></returns>
+        IEnumerable<AggregatedResult> AggregateResults(IEnumerable<TournamentResult> tournamentResults);
+
+        /// <summary>
         /// Aggregates the results of multiple tournaments and exports them to a CSV file
         /// </summary>
         /// <param name="tournamentIdsOrUrls"></param>

--- a/LichessTournamentAggregator/LichessTournamentAggregator.csproj
+++ b/LichessTournamentAggregator/LichessTournamentAggregator.csproj
@@ -7,7 +7,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Title>LichessTournamentAggregator</Title>
     <PackageId>LichessTournamentAggregator</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <PackageTags>Chess, Lichess, Tournament, Aggregator</PackageTags>
     <Tags>$(PackageTags)</Tags>
     <Authors>Eduardo Cáceres</Authors>


### PR DESCRIPTION
* Add `IEnumerable<AggregatedResult> AggregateResults(IEnumerable<TournamentResult>)` method to public api.

This would allow external results aggregation, providing the user of the library wraps their results around `TournamentResult`).