### PR TITLE
Make scores double

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# CSV files
+*.csv

--- a/LichessTournamentAggregator/LichessTournamentAggregator.csproj
+++ b/LichessTournamentAggregator/LichessTournamentAggregator.csproj
@@ -7,7 +7,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Title>LichessTournamentAggregator</Title>
     <PackageId>LichessTournamentAggregator</PackageId>
-    <Version>0.2.2</Version>
+    <Version>0.3.0</Version>
     <PackageTags>Chess, Lichess, Tournament, Aggregator</PackageTags>
     <Tags>$(PackageTags)</Tags>
     <Authors>Eduardo Cáceres</Authors>

--- a/LichessTournamentAggregator/LichessTournamentAggregator.csproj
+++ b/LichessTournamentAggregator/LichessTournamentAggregator.csproj
@@ -7,7 +7,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Title>LichessTournamentAggregator</Title>
     <PackageId>LichessTournamentAggregator</PackageId>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
     <PackageTags>Chess, Lichess, Tournament, Aggregator</PackageTags>
     <Tags>$(PackageTags)</Tags>
     <Authors>Eduardo Cáceres</Authors>
@@ -27,18 +27,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="4.7.1"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json">
-      <Version>4.7.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Text.Json">
-      <Version>4.7.1</Version>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/LichessTournamentAggregator/Model/AggregatedResult.cs
+++ b/LichessTournamentAggregator/Model/AggregatedResult.cs
@@ -13,7 +13,7 @@ namespace LichessTournamentAggregator.Model
         /// <summary>
         /// Sum of the scores of all the tournaments
         /// </summary>
-        public int TotalScores { get; set; }
+        public double TotalScores { get; set; }
 
         /// <summary>
         /// Maximum rating while playing in the tournaments
@@ -28,7 +28,7 @@ namespace LichessTournamentAggregator.Model
         /// <summary>
         /// Score in each tournament
         /// </summary>
-        public IEnumerable<int> Scores { get; set; }
+        public IEnumerable<double> Scores { get; set; }
 
         /// <summary>
         /// Average player performance in the tournaments.

--- a/LichessTournamentAggregator/Model/TournamentResult.cs
+++ b/LichessTournamentAggregator/Model/TournamentResult.cs
@@ -8,7 +8,7 @@ namespace LichessTournamentAggregator.Model
         public int Rank { get; set; }
 
         [JsonPropertyName("score")]
-        public int Score { get; set; }
+        public double Score { get; set; }
 
         [JsonPropertyName("rating")]
         public int Rating { get; set; }

--- a/LichessTournamentAggregator/TournamentAggregator.cs
+++ b/LichessTournamentAggregator/TournamentAggregator.cs
@@ -72,7 +72,7 @@ namespace LichessTournamentAggregator
             if (response.StatusCode != HttpStatusCode.OK)
             {
                 throw new ArgumentException("The following tournament url doesn't seem to exist",
-                    $"{url.OriginalString.Replace("/results", string.Empty)}");
+                    url.OriginalString.Replace("/results", string.Empty));
             }
 
             var rawContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -96,7 +96,7 @@ namespace LichessTournamentAggregator
             sw.WriteLine(string.Join(separator, headers));
 
             var internalSeparator = separator == ";" ? "," : ";";
-            string aggregate(IEnumerable<int> items) => $"[{string.Join(internalSeparator, items)}]";
+            string aggregate<T>(IEnumerable<T> items) => $"[{string.Join(internalSeparator, items)}]";
             foreach (var result in aggregatedResults)
             {
                 var columns = new string[] { result.Username, result.TotalScores.ToString(), result.AveragePerformance.ToString("F"), result.MaxRating.ToString(), aggregate(result.Ranks), aggregate(result.Scores) };


### PR DESCRIPTION
* Make scores `double` rather than `int`, to facilitate external usage.

Affected fields:
`AggregatedResult.TotalScores`, `AggregatedResult.Scores` and `TournamentResult.Score`.