### PR TITLE
Performance improvements

### DIFF
--- a/LichessTournamentAggregator/LichessTournamentAggregator.csproj
+++ b/LichessTournamentAggregator/LichessTournamentAggregator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="4.7.1"/>
+    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
   </ItemGroup>
 
 </Project>

--- a/LichessTournamentAggregator/LichessTournamentAggregator.csproj
+++ b/LichessTournamentAggregator/LichessTournamentAggregator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="4.7.1"/>
+    <PackageReference Include="System.Text.Json" Version="4.7.1" />
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />
   </ItemGroup>
 

--- a/LichessTournamentAggregator/TournamentAggregator.cs
+++ b/LichessTournamentAggregator/TournamentAggregator.cs
@@ -42,12 +42,12 @@ namespace LichessTournamentAggregator
 
         internal IEnumerable<Uri> GetUrls(IEnumerable<string> tournamentIdsOrUrls)
         {
+            const string lichessTournamentUrl = "lichess.org/tournament/";
             foreach (var item in tournamentIdsOrUrls.Select(str => str))
             {
-                var lichessTournamentUrl = "lichess.org/tournament/".AsSpan();
                 var tournamentId = item.AsSpan().Trim(new char[] { ' ', '/', '#' });
 
-                if (tournamentId.Contains(lichessTournamentUrl, StringComparison.InvariantCultureIgnoreCase))
+                if (tournamentId.Contains(lichessTournamentUrl.AsSpan(), StringComparison.InvariantCultureIgnoreCase))
                 {
                     tournamentId = tournamentId.Slice(tournamentId.LastIndexOf('/') + 1);
                 }

--- a/LichessTournamentAggregator/TournamentAggregator.cs
+++ b/LichessTournamentAggregator/TournamentAggregator.cs
@@ -1,4 +1,4 @@
-﻿using LichessTournamentAggregator.Model;
+using LichessTournamentAggregator.Model;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -49,18 +49,17 @@ namespace LichessTournamentAggregator
 
         internal IEnumerable<Uri> GetUrls(IEnumerable<string> tournamentIdsOrUrls)
         {
-            const string lichessTournamentUrl = "lichess.org/tournament/";
-            foreach (var item in tournamentIdsOrUrls.Select(str => str.Trim()))
+            foreach (var item in tournamentIdsOrUrls.Select(str => str))
             {
-                string tournamentId = item.Trim(new char[] { ' ', '/', '#' });
+                var lichessTournamentUrl = "lichess.org/tournament/".AsSpan();
+                var tournamentId = item.AsSpan().Trim(new char[] { ' ', '/', '#' });
 
-                if (tournamentId.Contains(lichessTournamentUrl))
+                if (tournamentId.Contains(lichessTournamentUrl, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    var reverse = string.Join("", tournamentId.Reverse());
-                    tournamentId = string.Join("", reverse.Take(reverse.IndexOf("/")).Reverse());
+                    tournamentId = tournamentId.Slice(tournamentId.LastIndexOf('/') + 1);
                 }
 
-                yield return new Uri($"https://lichess.org/api/tournament/{tournamentId}/results");
+                yield return new Uri($"https://lichess.org/api/tournament/{tournamentId.ToString()}/results");
             }
         }
 


### PR DESCRIPTION
* Reduce allocations by using `ReadOnlySpan` when handling strings
* `Use System.Linq.Async` LINQ extensions methods to properly handle `IAsyncEnumerable`.