### PR TITLE
Add swiss support

### DIFF
--- a/LichessTournamentAggregator.Test/AggregatedResultTest.cs
+++ b/LichessTournamentAggregator.Test/AggregatedResultTest.cs
@@ -109,6 +109,77 @@ namespace LichessTournamentAggregator.Test
         }
 
         [Fact]
+        public void TotalTieBreaks()
+        {
+            ICollection<TournamentResult> results = new[]
+            {
+                new TournamentResult()
+                {
+                    Username = Username,
+                    TieBreak = 0
+                },
+                new TournamentResult()
+                {
+                    Username = Username,
+                    TieBreak = 15
+                },
+                new TournamentResult()
+                {
+                    Username = Username,
+                    TieBreak = 5
+                },
+                new TournamentResult()
+                {
+                    Username = Username,
+                },
+                new TournamentResult()
+                {
+                    Username = Guid.NewGuid().ToString(),
+                    TieBreak = 7
+                },
+            };
+
+            AggregatedResult aggregatedResult = new AggregatedResult(results.GroupBy(r => r.Username).Single(g => g.Key == Username));
+
+            Assert.Equal(results.Where(r => r.Username == Username).Sum(r => r.TieBreak), aggregatedResult.TotalTieBreaks);
+        }
+
+        [Fact]
+        public void TieBreaks()
+        {
+            ICollection<TournamentResult> results = new[]
+            {
+                new TournamentResult()
+                {
+                    Username = Username,
+                    TieBreak = 0
+                },
+                new TournamentResult()
+                {
+                    Username = Username,
+                    TieBreak = 15
+                },
+                new TournamentResult()
+                {
+                    Username = Username,
+                    TieBreak = 5
+                },
+                new TournamentResult()
+                {
+                    Username = Guid.NewGuid().ToString(),
+                    TieBreak = 7
+                },
+            };
+
+            AggregatedResult aggregatedResult = new AggregatedResult(results.GroupBy(r => r.Username).Single(g => g.Key == Username));
+
+            foreach (var tieBreak in aggregatedResult.TieBreaks)
+            {
+                Assert.Single(results, (result) => result.Username == aggregatedResult.Username && result.TieBreak == tieBreak);
+            }
+        }
+
+        [Fact]
         public void Ranks()
         {
             ICollection<TournamentResult> results = new[]

--- a/LichessTournamentAggregator.Test/AggregatedResultTest.cs
+++ b/LichessTournamentAggregator.Test/AggregatedResultTest.cs
@@ -45,17 +45,22 @@ namespace LichessTournamentAggregator.Test
                 new TournamentResult()
                 {
                     Username = Username,
-                    Score = 0
+                    Score = 60_227_444
                 },
                 new TournamentResult()
                 {
                     Username = Username,
-                    Score = 15
+                    Score = 60_999_999
                 },
                 new TournamentResult()
                 {
                     Username = Username,
-                    Score = 5
+                    Score = 45_129_774
+                },
+                new TournamentResult()
+                {
+                    Username = Username,
+                    Score = 35_094_397
                 },
                 new TournamentResult()
                 {
@@ -64,48 +69,68 @@ namespace LichessTournamentAggregator.Test
                 new TournamentResult()
                 {
                     Username = Guid.NewGuid().ToString(),
-                    Score = 7
+                    Score = 35_094_397
                 },
             };
 
             AggregatedResult aggregatedResult = new AggregatedResult(results.GroupBy(r => r.Username).Single(g => g.Key == Username));
 
-            Assert.Equal(results.Where(r => r.Username == Username).Sum(r => r.Score), aggregatedResult.TotalScores);
+            Assert.Equal(20, aggregatedResult.TotalScores);
         }
 
-        [Fact]
-        public void Scores()
+        [Theory]
+        [InlineData(299_999_999, 29.5)]
+        [InlineData(258_772_232, 25.5)]
+        [InlineData(248_289_662, 24.5)]
+        [InlineData(243_922_155, 24)]
+        [InlineData(45_129_774, 4.5)]
+        [InlineData(30_036_709, 3)]
+        [InlineData(20_021_986, 2)]
+        [InlineData(10_001_592, 1)]
+        [InlineData(5_000_709, 0.5)]
+        [InlineData(1_720, 0)]
+        public void Scores(double lichessScore, double expectedCalculatedScore)
         {
+            var result = new TournamentResult()
+            {
+                Username = Username,
+                Score = lichessScore
+            };
+
             ICollection<TournamentResult> results = new[]
             {
+                result,
                 new TournamentResult()
                 {
-                    Username = Username,
-                    Score = 0
-                },
-                new TournamentResult()
-                {
-                    Username = Username,
-                    Score = 15
-                },
-                new TournamentResult()
-                {
-                    Username = Username,
-                    Score = 5
+                    Username = $"{Username} ",
+                    Score = 30_036_709
                 },
                 new TournamentResult()
                 {
                     Username = Guid.NewGuid().ToString(),
-                    Score = 7
+                    Score = 24_392_2155
+                },
+                new TournamentResult()
+                {
+                    Username = Username,
+                    Score = 260_001_592
+                },
+                new TournamentResult()
+                {
+                    Username = Username,
+                    Score = 50_001_592
+                },
+                new TournamentResult()
+                {
+                    Username = Guid.NewGuid().ToString(),
+                    Score = 1_720
                 },
             };
 
-            AggregatedResult aggregatedResult = new AggregatedResult(results.GroupBy(r => r.Username).Single(g => g.Key == Username));
+            var aggregatedResult = new AggregatedResult(results.GroupBy(r => r.Username).Single(g => g.Key == result.Username));
 
-            foreach (var score in aggregatedResult.Scores)
-            {
-                Assert.Single(results, (result) => result.Username == aggregatedResult.Username && result.Score == score);
-            }
+            Assert.Equal(aggregatedResult.Username, result.Username);
+            Assert.Single(aggregatedResult.Scores, (score) => score == expectedCalculatedScore);
         }
 
         [Fact]

--- a/LichessTournamentAggregator/Model/AggregatedResult.cs
+++ b/LichessTournamentAggregator/Model/AggregatedResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace LichessTournamentAggregator.Model
@@ -56,11 +57,22 @@ namespace LichessTournamentAggregator.Model
             Title = results.First().Title;
             MaxRating = results.Max(p => p.Rating);
             Ranks = results.Select(p => p.Rank);
-            Scores = results.Select(p => p.Score);
+            Scores = results.Select(p => CalculatePoints(p.Score));
             TieBreaks = results.Select(p => p.TieBreak);
-            TotalScores = results.Select(p => p.Score).Sum();
-            TotalTieBreaks = results.Select(p => p.TieBreak).Sum();
+            TotalScores = Scores.Sum();
+            TotalTieBreaks = TieBreaks.Sum();
             AveragePerformance = (double)results.Select(p => p.Performance).Sum() / results.Count(p => p.Rank != 0);
+        }
+
+        /// <summary>
+        /// Lichess score: https://github.com/lichess-org/api/issues/99
+        /// </summary>
+        /// <param name="lichessScore"></param>
+        /// <returns></returns>
+        private static double CalculatePoints(double lichessScore)
+        {
+            // Flooring to the nearest half, see https://stackoverflow.com/questions/1329426/how-do-i-round-to-the-nearest-0-5
+            return Math.Floor(2 * (lichessScore / 10_000_000)) / 2;
         }
     }
 }

--- a/LichessTournamentAggregator/Model/AggregatedResult.cs
+++ b/LichessTournamentAggregator/Model/AggregatedResult.cs
@@ -21,6 +21,11 @@ namespace LichessTournamentAggregator.Model
         public double TotalScores { get; set; }
 
         /// <summary>
+        /// Sum of the Tie Breaks of all the tournaments
+        /// </summary>
+        public double TotalTieBreaks { get; set; }
+
+        /// <summary>
         /// Maximum rating while playing in the tournaments
         /// </summary>
         public double MaxRating { get; set; }
@@ -36,6 +41,11 @@ namespace LichessTournamentAggregator.Model
         public IEnumerable<double> Scores { get; set; }
 
         /// <summary>
+        /// Tie breaks in each tournament
+        /// </summary>
+        public IEnumerable<double> TieBreaks { get; set; }
+
+        /// <summary>
         /// Average player performance in the tournaments.
         /// </summary>
         public double AveragePerformance { get; set; }
@@ -47,7 +57,9 @@ namespace LichessTournamentAggregator.Model
             MaxRating = results.Max(p => p.Rating);
             Ranks = results.Select(p => p.Rank);
             Scores = results.Select(p => p.Score);
+            TieBreaks = results.Select(p => p.TieBreak);
             TotalScores = results.Select(p => p.Score).Sum();
+            TotalTieBreaks = results.Select(p => p.TieBreak).Sum();
             AveragePerformance = (double)results.Select(p => p.Performance).Sum() / results.Count(p => p.Rank != 0);
         }
     }

--- a/LichessTournamentAggregator/Model/TournamentResult.cs
+++ b/LichessTournamentAggregator/Model/TournamentResult.cs
@@ -10,6 +10,12 @@ namespace LichessTournamentAggregator.Model
         [JsonPropertyName("score")]
         public double Score { get; set; }
 
+        /// <summary>
+        /// Only swiss
+        /// </summary>
+        [JsonPropertyName("tieBreak")]
+        public double TieBreak { get; set; }
+
         [JsonPropertyName("rating")]
         public int Rating { get; set; }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
 - stage: CD
   displayName: 'Generate and publish artifacts'
   dependsOn: 'CI'
-  condition: succeeded('CI')
+  condition: and(succeeded('CI'), ne(variables['Build.Reason'], 'Schedule'))
   jobs:
   - job: cd
     displayName: 'Generate and publish artifacts'
@@ -79,7 +79,7 @@ stages:
       displayName: 'Generate NuGet package'
       inputs:
         command: 'pack'
-        arguments: '--configuration Release'
+        arguments: '--configuration Release --no-build'
         configuration: '$(BuildConfiguration)'
         packagesToPack: '**/*LichessTournamentAggregator.csproj'
         nobuild: true
@@ -90,7 +90,7 @@ stages:
       displayName: 'Generate executable for $(Windowsx64)'
       inputs:
         command: 'publish'
-        arguments: '--configuration Release --runtime $(Windowsx64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Windowsx64)'
+        arguments: '--configuration Release --no-build --runtime $(Windowsx64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Windowsx64)'
         configuration: '$(BuildConfiguration)'
         projects: '**/*.App.csproj'
         modifyOutputPath: false
@@ -102,7 +102,7 @@ stages:
       displayName: 'Generate executable for $(Windowsx86)'
       inputs:
         command: 'publish'
-        arguments: '--configuration Release --runtime $(Windowsx86) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Windowsx86)'
+        arguments: '--configuration Release --no-build --runtime $(Windowsx86) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Windowsx86)'
         configuration: '$(BuildConfiguration)'
         projects: '**/*.App.csproj'
         modifyOutputPath: false
@@ -114,7 +114,7 @@ stages:
       displayName: 'Generate executable for $(Linux64)'
       inputs:
         command: 'publish'
-        arguments: '--configuration Release --runtime $(Linux64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Linux64)'
+        arguments: '--configuration Release --no-build --runtime $(Linux64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Linux64)'
         configuration: '$(BuildConfiguration)'
         projects: '**/*.App.csproj'
         modifyOutputPath: false
@@ -126,7 +126,7 @@ stages:
       displayName: 'Generate executable for $(OSXx64)'
       inputs:
         command: 'publish'
-        arguments: '--configuration Release --runtime $(OSXx64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(OSXx64)'
+        arguments: '--configuration Release --no-build --runtime $(OSXx64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(OSXx64)'
         configuration: '$(BuildConfiguration)'
         projects: '**/*.App.csproj'
         modifyOutputPath: false
@@ -142,7 +142,7 @@ stages:
 
     - task: NuGetCommand@2
       displayName: 'Push NuGet package'
-      condition: and(ne(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      condition: and(eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       continueOnError: true
       inputs:
         command: 'push'
@@ -153,7 +153,7 @@ stages:
 
     - task: NuGetCommand@2
       displayName: 'Push GitHub package'
-      condition: and(ne(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      condition: and(eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       continueOnError: true
       inputs:
         command: 'push'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
 - stage: CD
   displayName: 'Generate and publish artifacts'
   dependsOn: 'CI'
-  condition: and(succeeded('CI'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: succeeded('CI')
   jobs:
   - job: cd
     displayName: 'Generate and publish artifacts'
@@ -142,7 +142,7 @@ stages:
 
     - task: NuGetCommand@2
       displayName: 'Push NuGet package'
-      condition: ne(variables['Build.Reason'], 'Schedule')
+      condition: and(ne(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       continueOnError: true
       inputs:
         command: 'push'
@@ -153,7 +153,7 @@ stages:
 
     - task: NuGetCommand@2
       displayName: 'Push GitHub package'
-      condition: ne(variables['Build.Reason'], 'Schedule')
+      condition: and(ne(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       continueOnError: true
       inputs:
         command: 'push'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ stages:
       displayName: 'Generate NuGet package'
       inputs:
         command: 'pack'
-        arguments: '--configuration Release --no-build'
+        arguments: '--configuration Release'
         configuration: '$(BuildConfiguration)'
         packagesToPack: '**/*LichessTournamentAggregator.csproj'
         nobuild: true
@@ -90,7 +90,7 @@ stages:
       displayName: 'Generate executable for $(Windowsx64)'
       inputs:
         command: 'publish'
-        arguments: '--configuration Release --no-build --runtime $(Windowsx64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Windowsx64)'
+        arguments: '--configuration Release --runtime $(Windowsx64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Windowsx64)'
         configuration: '$(BuildConfiguration)'
         projects: '**/*.App.csproj'
         modifyOutputPath: false
@@ -102,7 +102,7 @@ stages:
       displayName: 'Generate executable for $(Windowsx86)'
       inputs:
         command: 'publish'
-        arguments: '--configuration Release --no-build --runtime $(Windowsx86) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Windowsx86)'
+        arguments: '--configuration Release --runtime $(Windowsx86) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Windowsx86)'
         configuration: '$(BuildConfiguration)'
         projects: '**/*.App.csproj'
         modifyOutputPath: false
@@ -114,7 +114,7 @@ stages:
       displayName: 'Generate executable for $(Linux64)'
       inputs:
         command: 'publish'
-        arguments: '--configuration Release --no-build --runtime $(Linux64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Linux64)'
+        arguments: '--configuration Release --runtime $(Linux64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(Linux64)'
         configuration: '$(BuildConfiguration)'
         projects: '**/*.App.csproj'
         modifyOutputPath: false
@@ -126,7 +126,7 @@ stages:
       displayName: 'Generate executable for $(OSXx64)'
       inputs:
         command: 'publish'
-        arguments: '--configuration Release --no-build --runtime $(OSXx64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(OSXx64)'
+        arguments: '--configuration Release --runtime $(OSXx64) --output $(Build.SourcesDirectory)/LichessTournamentAggregator/Artifacts/$(OSXx64)'
         configuration: '$(BuildConfiguration)'
         projects: '**/*.App.csproj'
         modifyOutputPath: false


### PR DESCRIPTION
* Add basic swiss support:
  * Include `TieBreaks` and `TotalTieBreaks` fields, which will be empty for Arena tournaments.
  * Use `TieBreaks` field as second tie break.
  * Show swiss points and total swiss points in `Scores` and `TotalScores`, as if/together with arena ones.

* Make API queries sequential, to avoid rate limit issues.

This closes #15.