### PR TITLE
Fix Swiss score calculation

### DIFF
--- a/LichessTournamentAggregator.App/LichessTournamentAggregator.App.csproj
+++ b/LichessTournamentAggregator.App/LichessTournamentAggregator.App.csproj
@@ -7,7 +7,7 @@
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <Authors>Eduardo Cáceres</Authors>
     <Description>
       Multiplatform desktop app that allows you to aggregate the results of multiple Lichess tournaments

--- a/LichessTournamentAggregator.Test/AggregatedResultTest.cs
+++ b/LichessTournamentAggregator.Test/AggregatedResultTest.cs
@@ -38,29 +38,29 @@ namespace LichessTournamentAggregator.Test
         }
 
         [Fact]
-        public void TotalScores()
+        public void Scores_TotalScores()
         {
             ICollection<TournamentResult> results = new[]
             {
                 new TournamentResult()
                 {
                     Username = Username,
-                    Score = 60_227_444
+                    Score = 6.5
                 },
                 new TournamentResult()
                 {
                     Username = Username,
-                    Score = 60_999_999
+                    Score = 7
                 },
                 new TournamentResult()
                 {
                     Username = Username,
-                    Score = 45_129_774
+                    Score = 5
                 },
                 new TournamentResult()
                 {
                     Username = Username,
-                    Score = 35_094_397
+                    Score = 2
                 },
                 new TournamentResult()
                 {
@@ -69,68 +69,17 @@ namespace LichessTournamentAggregator.Test
                 new TournamentResult()
                 {
                     Username = Guid.NewGuid().ToString(),
-                    Score = 35_094_397
+                    Score = 1_000
                 },
             };
 
             AggregatedResult aggregatedResult = new AggregatedResult(results.GroupBy(r => r.Username).Single(g => g.Key == Username));
 
-            Assert.Equal(20, aggregatedResult.TotalScores);
-        }
-
-        [Theory]
-        [InlineData(299_999_999, 29.5)]
-        [InlineData(258_772_232, 25.5)]
-        [InlineData(248_289_662, 24.5)]
-        [InlineData(243_922_155, 24)]
-        [InlineData(45_129_774, 4.5)]
-        [InlineData(30_036_709, 3)]
-        [InlineData(20_021_986, 2)]
-        [InlineData(10_001_592, 1)]
-        [InlineData(5_000_709, 0.5)]
-        [InlineData(1_720, 0)]
-        public void Scores(double lichessScore, double expectedCalculatedScore)
-        {
-            var result = new TournamentResult()
+            Assert.Equal(20.5, aggregatedResult.TotalScores);
+            foreach (var result in results.Where(r => r.Username == Username))
             {
-                Username = Username,
-                Score = lichessScore
-            };
-
-            ICollection<TournamentResult> results = new[]
-            {
-                result,
-                new TournamentResult()
-                {
-                    Username = $"{Username} ",
-                    Score = 30_036_709
-                },
-                new TournamentResult()
-                {
-                    Username = Guid.NewGuid().ToString(),
-                    Score = 24_392_2155
-                },
-                new TournamentResult()
-                {
-                    Username = Username,
-                    Score = 260_001_592
-                },
-                new TournamentResult()
-                {
-                    Username = Username,
-                    Score = 50_001_592
-                },
-                new TournamentResult()
-                {
-                    Username = Guid.NewGuid().ToString(),
-                    Score = 1_720
-                },
-            };
-
-            var aggregatedResult = new AggregatedResult(results.GroupBy(r => r.Username).Single(g => g.Key == result.Username));
-
-            Assert.Equal(aggregatedResult.Username, result.Username);
-            Assert.Single(aggregatedResult.Scores, (score) => score == expectedCalculatedScore);
+                Assert.Contains(result.Score, aggregatedResult.Scores);
+            }
         }
 
         [Fact]

--- a/LichessTournamentAggregator/LichessTournamentAggregator.csproj
+++ b/LichessTournamentAggregator/LichessTournamentAggregator.csproj
@@ -7,7 +7,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Title>LichessTournamentAggregator</Title>
     <PackageId>LichessTournamentAggregator</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <PackageTags>Chess, Lichess, Tournament, Aggregator</PackageTags>
     <Tags>$(PackageTags)</Tags>
     <Authors>Eduardo Cáceres</Authors>

--- a/LichessTournamentAggregator/Model/AggregatedResult.cs
+++ b/LichessTournamentAggregator/Model/AggregatedResult.cs
@@ -57,22 +57,11 @@ namespace LichessTournamentAggregator.Model
             Title = results.First().Title;
             MaxRating = results.Max(p => p.Rating);
             Ranks = results.Select(p => p.Rank + 1);
-            Scores = results.Select(p => CalculatePoints(p.Score));
+            Scores = results.Select(p => p.Score >= p.Points ? p.Score : p.Points);  // A TournamentResult should only have either Score (Arena tournaments) or Points (Swiss tournaments)
             TieBreaks = results.Select(p => p.TieBreak);
             TotalScores = Scores.Sum();
             TotalTieBreaks = TieBreaks.Sum();
             AveragePerformance = (double)results.Select(p => p.Performance).Sum() / results.Count();
-        }
-
-        /// <summary>
-        /// Lichess score: https://github.com/lichess-org/api/issues/99
-        /// </summary>
-        /// <param name="lichessScore"></param>
-        /// <returns></returns>
-        private static double CalculatePoints(double lichessScore)
-        {
-            // Flooring to the nearest half, see https://stackoverflow.com/questions/1329426/how-do-i-round-to-the-nearest-0-5
-            return Math.Floor(2 * (lichessScore / 10_000_000)) / 2;
         }
     }
 }

--- a/LichessTournamentAggregator/Model/TournamentResult.cs
+++ b/LichessTournamentAggregator/Model/TournamentResult.cs
@@ -7,8 +7,17 @@ namespace LichessTournamentAggregator.Model
         [JsonPropertyName("rank")]
         public int Rank { get; set; }
 
+        /// <summary>
+        /// Only arena
+        /// </summary>
         [JsonPropertyName("score")]
         public double Score { get; set; }
+
+        /// <summary>
+        /// Only swiss
+        /// </summary>
+        [JsonPropertyName("points")]
+        public double Points { get; set; }
 
         /// <summary>
         /// Only swiss


### PR DESCRIPTION
Add `TournamentResult.Points`, mapped to JSON "points" field (https://github.com/ornicar/lila/commit/1dcc67e4253cca36a58a32da0c7c9042db47bec8).

It contains the points scored by a player in a swiss tournament, making `AggregatedResult.CalculatePoints` unnecessary.
This fixes #23.